### PR TITLE
fix(HFChat): Update HFChat for compatibility with transformers>=1.45.0

### DIFF
--- a/jailbreakeval/services/chat/service_base.py
+++ b/jailbreakeval/services/chat/service_base.py
@@ -13,7 +13,7 @@ class ChatService(ABC):
     def __init__(self, model: Optional[str] = None, chat_kwargs: Optional[Dict[str, Any]] = None, **kwargs) -> None:
         super().__init__()
         self.model = model
-        self.chat_kwargs = deepcopy(chat_kwargs) or {}
+        self.chat_kwargs = deepcopy(chat_kwargs or {})
 
     @classmethod
     def __init_subclass__(cls, service_type: Optional[str] = None, **kwargs):

--- a/jailbreakeval/services/chat/transformers_pipeline_service.py
+++ b/jailbreakeval/services/chat/transformers_pipeline_service.py
@@ -19,6 +19,8 @@ class TransformersPipelineChatService(ChatService, service_type="transformers-pi
     ) -> None:
         self.pipeline = pipeline or pipeline_factory(task="text-generation", model=model, **pipeline_kwargs)
         super().__init__(self.pipeline.model.name_or_path, chat_kwargs)
+        self.chat_kwargs["return_full_text"] = False
+        self.chat_kwargs["continue_final_message"] = False
 
     def chat(self, conversation: Sequence[Message], **override_chat_kwargs) -> str:
         chat_kwargs = copy.deepcopy(self.chat_kwargs)
@@ -26,4 +28,4 @@ class TransformersPipelineChatService(ChatService, service_type="transformers-pi
             if k in chat_kwargs:
                 chat_kwargs.pop(k)
         result = self.pipeline(text_inputs=conversation, **chat_kwargs, **override_chat_kwargs)
-        return result[0]["generated_text"][-1]["content"]
+        return result[0]["generated_text"]

--- a/jailbreakeval/services/text_classification/service_base.py
+++ b/jailbreakeval/services/text_classification/service_base.py
@@ -11,7 +11,7 @@ class TextClassificationService(ABC):
     def __init__(self, model: Optional[str] = None, predict_kwargs: Optional[Dict[str, Any]] = None, **kwargs) -> None:
         super().__init__()
         self.model = model
-        self.predict_kwargs = deepcopy(predict_kwargs) or {}
+        self.predict_kwargs = deepcopy(predict_kwargs or {})
 
     @classmethod
     def __init_subclass__(cls, service_type: Optional[str] = None, **kwargs) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "numpy",
     "tqdm",
     "jinja2",
-    "transformers>=4.38.0",
+    "transformers>=4.45.0",
     "torch",
     "accelerate",
     "sentencepiece",

--- a/tests/evaluators/test_chat_evaluator.py
+++ b/tests/evaluators/test_chat_evaluator.py
@@ -31,6 +31,8 @@ def test_transformers_pipeline(mock_transformers_pipeline_call, mock_chat_servic
         ],
         temperature=0.0,
         max_new_tokens=20,
+        return_full_text=False,
+        continue_final_message=False,
     )
     assert not result
 

--- a/tests/services/chat/test_transformers_pipeline_service.py
+++ b/tests/services/chat/test_transformers_pipeline_service.py
@@ -42,13 +42,17 @@ def test_predict(mock_transformers_pipeline_call):
 
     service = TransformersPipelineChatService(model=MODEL)
     response = service.chat(MESSAGES)
-    mock_transformers_pipeline_call.assert_called_with(text_inputs=MESSAGES)
+    mock_transformers_pipeline_call.assert_called_with(
+        text_inputs=MESSAGES, return_full_text=False, continue_final_message=False
+    )
     assert isinstance(response, str)
     assert response == RESPONSE
 
     # override
     response = service.chat(MESSAGES, key="value")
-    mock_transformers_pipeline_call.assert_called_with(text_inputs=MESSAGES, key="value")
+    mock_transformers_pipeline_call.assert_called_with(
+        text_inputs=MESSAGES, key="value", return_full_text=False, continue_final_message=False
+    )
     assert isinstance(response, str)
     assert response == RESPONSE
 
@@ -56,13 +60,22 @@ def test_predict(mock_transformers_pipeline_call):
     service = TransformersPipelineChatService(model=MODEL, chat_kwargs={"hello": "world", "foo": "bar"})
     response = service.chat(MESSAGES)
 
-    mock_transformers_pipeline_call.assert_called_with(text_inputs=MESSAGES, hello="world", foo="bar")
+    mock_transformers_pipeline_call.assert_called_with(
+        text_inputs=MESSAGES, hello="world", foo="bar", return_full_text=False, continue_final_message=False
+    )
     assert isinstance(response, str)
     assert response == RESPONSE
 
     # gen_kwargs + override
-    response = service.chat(MESSAGES, foo="baz", key="value")
+    response = service.chat(MESSAGES, foo="baz", key="value", return_full_text=False, continue_final_message=False)
 
-    mock_transformers_pipeline_call.assert_called_with(text_inputs=MESSAGES, hello="world", foo="baz", key="value")
+    mock_transformers_pipeline_call.assert_called_with(
+        text_inputs=MESSAGES,
+        hello="world",
+        foo="baz",
+        key="value",
+        return_full_text=False,
+        continue_final_message=False,
+    )
     assert isinstance(response, str)
     assert response == RESPONSE

--- a/tests/testing_utils.py
+++ b/tests/testing_utils.py
@@ -99,7 +99,7 @@ def transformers_chat_pipeline_response(
         response = [response]
     chat_id = str(uuid.uuid4())
     for i, response in enumerate(response):
-        yield [{"mock_id": f"mock-{chat_id}-{i}", "generated_text": [{"role": "assistance", "content": response}]}]
+        yield [{"mock_id": f"mock-{chat_id}-{i}", "generated_text": response}]
 
 
 # %%


### PR DESCRIPTION
Fix #8.

The inference template for LlamaGuard ends with a message from the assistant. An update since `transformers>=1.45.0` will continue with this message instead of inferring the harmfulness.

Cross Ref: https://github.com/huggingface/transformers/pull/33198