### PR TITLE
build(release): bump pypa/gh-action-pypi-publish version to v1.12.4

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,10 +26,10 @@ jobs:
     - name: Build package
       run: python -m build
     - name: publish to Test PyPI
-      uses: pypa/gh-action-pypi-publish@v1.8.14
+      uses: pypa/gh-action-pypi-publish@v1.12.4
       continue-on-error: true
       with:
         repository-url: https://test.pypi.org/legacy/
     - name: Publish to PyPI
       if: github.event_name == 'release' && github.event.action == 'published'
-      uses: pypa/gh-action-pypi-publish@v1.8.14
+      uses: pypa/gh-action-pypi-publish@v1.12.4


### PR DESCRIPTION
**What does this PR do?**
bump `pypa/gh-action-pypi-publish` version to v1.12.4 to solve the error for metadata mismatch.
```
Checking dist/jailbreakeval-0.0.3-py3-none-any.whl: ERROR    InvalidDistribution: Metadata is missing required fields: Name,        
         Version.                                                               
         Make sure the distribution includes the files where those fields are   
         specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2,   
         2.0, 2.1, 2.2, 2.3.                                               
```
Cross ref: https://github.com/pypa/gh-action-pypi-publish/issues/310

**Please check all applicable items before submitting:**
- [x] Have you read the [contributing guidelines](https://github.com/ThuCCSLab/JailbreakEval/blob/main/CONTRIBUTING.md)?
- [ ] Does this PR only fix typos or improve the documentation (you can skip the other checks if that's the case)?
- [ ] Is this PR related to a GitHub issue? If so, have you linked to it?
- [ ] Have you written any necessary new tests?
- [ ] Have all tests passed in your development environment, both existing and new?
- [ ] Have you updated the documentation with your changes?
- [ ] Have you run the pre-commit checks for code quality?
