### PR TITLE
build(release): disable attestations for publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,6 +30,9 @@ jobs:
       continue-on-error: true
       with:
         repository-url: https://test.pypi.org/legacy/
+        attestations: false
     - name: Publish to PyPI
       if: github.event_name == 'release' && github.event.action == 'published'
       uses: pypa/gh-action-pypi-publish@v1.12.4
+      with:
+        attestations: false


### PR DESCRIPTION
**What does this PR do?**
Disable attestations in GitHub workflow because this feature is not stable for now.

Cross Ref: https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#generating-and-uploading-attestations

**Please check all applicable items before submitting:**
- [x] Have you read the [contributing guidelines](https://github.com/ThuCCSLab/JailbreakEval/blob/main/CONTRIBUTING.md)?
- [ ] Does this PR only fix typos or improve the documentation (you can skip the other checks if that's the case)?
- [ ] Is this PR related to a GitHub issue? If so, have you linked to it?
- [ ] Have you written any necessary new tests?
- [ ] Have all tests passed in your development environment, both existing and new?
- [ ] Have you updated the documentation with your changes?
- [ ] Have you run the pre-commit checks for code quality?
