### PR TITLE
fix(CLI): Fix #24 by only shows agreement results when `label` column is present

### DIFF
--- a/jailbreakeval/commands/main.py
+++ b/jailbreakeval/commands/main.py
@@ -191,8 +191,6 @@ def main(
                 }
 
             del evaluator
-            gc.collect()
-            torch.cuda.empty_cache()
         except Exception as e:
             logger.error(f"Failed to evaluate {evaluator_id}: {e}")
         finally:

--- a/jailbreakeval/commands/main.py
+++ b/jailbreakeval/commands/main.py
@@ -92,20 +92,19 @@ def load_csv_dataset(filepath):
 
     if "label" not in dataset:
         dataset["label"] = pd.NA
-        dataset["label"] = dataset["label"].astype("boolean")
     return dataset
 
 
 def eval_metrics(labels, preds):
-    labels = pd.Series(labels, dtype="boolean")
     preds = pd.Series(preds, dtype="boolean")
     non_na_preds = ~preds.isna()
-    non_na_labels = ~labels.isna()
-    non_na_intersected = non_na_labels & non_na_preds
     metrics = {
         "coverage": non_na_preds.mean(),
         "jailbreak_ratio": preds[non_na_preds].mean(),
     }
+    labels = pd.Series(labels, dtype="boolean")
+    non_na_labels = ~labels.isna()
+    non_na_intersected = non_na_labels & non_na_preds
     if any(non_na_labels):
         metrics["labelled_coverage"] = non_na_intersected.sum() / non_na_labels.sum()
     if any(non_na_intersected):
@@ -135,20 +134,23 @@ def main(
         config = yaml.safe_load(Path(config_filepath).read_text())
     else:
         config = {}
-
     dataset = load_csv_dataset(dataset_filepath)
-
+    hasLabels = not dataset["label"].isna().all()
     labels = dataset["label"].astype("O").replace(pd.NA, None).to_list()
 
-    results = {
-        "Annotation": {
-            "preds": labels,
-            **eval_metrics(
-                pd.Series([None] * len(dataset["label"]), dtype="boolean"),
-                dataset["label"],
-            ),
+    results = (
+        {
+            "Annotation": {
+                "preds": labels,
+                **eval_metrics(
+                    pd.Series([None] * len(dataset["label"]), dtype="boolean"),
+                    dataset["label"],
+                ),
+            }
         }
-    }
+        if hasLabels
+        else {}
+    )
 
     for evaluator_id in evaluators:
         try:
@@ -189,6 +191,8 @@ def main(
                 }
 
             del evaluator
+            gc.collect()
+            torch.cuda.empty_cache()
         except Exception as e:
             logger.error(f"Failed to evaluate {evaluator_id}: {e}")
         finally:
@@ -209,13 +213,14 @@ def main(
             + [v.get("time_ms", "N/A"), v.get("prompt_tokens_usage", "N/A"), v.get("completion_tokens_usage", "N/A")]
         )
     print(tb)
-    print("Evaluation agreement with annotation:")
-    tb = PrettyTable(["name", "coverage", "accuracy", "recall", "precision", "f1"])
-    tb.float_format = ".2"
-    for k, v in results.items():
-        if k != "Annotation":
-            tb.add_row([k, v["labelled_coverage"], v["accuracy"], v["recall"], v["precision"], v["f1"]])
-    print(tb)
+    if hasLabels:
+        print("Evaluation agreement with annotation:")
+        tb = PrettyTable(["name", "coverage", "accuracy", "recall", "precision", "f1"])
+        tb.float_format = ".2"
+        for k, v in results.items():
+            if k != "Annotation":
+                tb.add_row([k, v["labelled_coverage"], v["accuracy"], v["recall"], v["precision"], v["f1"]])
+        print(tb)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix #24.

**What does this PR do?**
After this fix, the evaluator will not print the metrics between preds and the annotation when there's no `label` present in the dataset.

**Please check all applicable items before submitting:**
- [x] Have you read the [contributing guidelines](https://github.com/ThuCCSLab/JailbreakEval/blob/main/CONTRIBUTING.md)?
- [ ] Does this PR only fix typos or improve the documentation (you can skip the other checks if that's the case)?
- [x] Is this PR related to a GitHub issue? If so, have you linked to it?
- [ ] Have you written any necessary new tests?
- [x] Have all tests passed in your development environment, both existing and new?
- [ ] Have you updated the documentation with your changes?
- [x] Have you run the pre-commit checks for code quality?
